### PR TITLE
remove ul and li selectors and size secondary image

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -12,114 +12,17 @@
 .pif-has-gallery .secondary-image {
     position: absolute;
     top:0;
-    left:0;
+    left:15px;
     opacity:0;
+    -webkit-transition: opacity .3s ease-in-out;
+       -moz-transition: opacity .3s ease-in-out;
+        -ms-transition: opacity .3s ease-in-out;
+         -o-transition: opacity .3s ease-in-out;
+            transition: opacity .3s ease-in-out;
 }
-
-
- /**
- * Animation
- */
-.animated{-webkit-animation-fill-mode:both;-moz-animation-fill-mode:both;-ms-animation-fill-mode:both;-o-animation-fill-mode:both;animation-fill-mode:both;-webkit-animation-duration:.5s;-moz-animation-duration:.5s;-ms-animation-duration:.5s;-o-animation-duration:.5s;animation-duration:.5s;}.animated.hinge{-webkit-animation-duration:1s;-moz-animation-duration:1s;-ms-animation-duration:1s;-o-animation-duration:1s;animation-duration:1s;}@-webkit-keyframes fadeInDown {
-    0% {
-        opacity: 0;
-        -webkit-transform: translateY(-20px);
-    }   100% {
-        opacity: 1;
-        -webkit-transform: translateY(0);
-    }
-}
-
-@-moz-keyframes fadeInDown {
-    0% {
-        opacity: 0;
-        -moz-transform: translateY(-20px);
-    }
-
-    100% {
-        opacity: 1;
-        -moz-transform: translateY(0);
-    }
-}
-
-@-o-keyframes fadeInDown {
-    0% {
-        opacity: 0;
-        -o-transform: translateY(-20px);
-    }
-
-    100% {
-        opacity: 1;
-        -o-transform: translateY(0);
-    }
-}
-
-@keyframes fadeInDown {
-    0% {
-        opacity: 0;
-        transform: translateY(-20px);
-    }
-
-    100% {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-.fadeInDown {
-    -webkit-animation-name: fadeInDown;
-    -moz-animation-name: fadeInDown;
-    -o-animation-name: fadeInDown;
-    animation-name: fadeInDown;
-}
-@-webkit-keyframes fadeOutUp {
-    0% {
-        opacity: 1;
-        -webkit-transform: translateY(0);
-    }
-
-    100% {
-        opacity: 0;
-        -webkit-transform: translateY(-20px);
-    }
-}
-@-moz-keyframes fadeOutUp {
-    0% {
-        opacity: 1;
-        -moz-transform: translateY(0);
-    }
-
-    100% {
-        opacity: 0;
-        -moz-transform: translateY(-20px);
-    }
-}
-@-o-keyframes fadeOutUp {
-    0% {
-        opacity: 1;
-        -o-transform: translateY(0);
-    }
-
-    100% {
-        opacity: 0;
-        -o-transform: translateY(-20px);
-    }
-}
-@keyframes fadeOutUp {
-    0% {
-        opacity: 1;
-        transform: translateY(0);
-    }
-
-    100% {
-        opacity: 0;
-        transform: translateY(-20px);
-    }
-}
-
 .fadeOutUp {
-    -webkit-animation-name: fadeOutUp;
-    -moz-animation-name: fadeOutUp;
-    -o-animation-name: fadeOutUp;
-    animation-name: fadeOutUp;
+    opacity: 0;
+}
+.fadeInDown {
+    opacity: 1!important;
 }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,7 +1,9 @@
 jQuery(document).ready(function($){
-	jQuery( 'ul.products li.pif-has-gallery a:first-child' ).hover( function() {
+	jQuery( '.products .pif-has-gallery a:first-child' ).hover( function() {
 		jQuery( this ).children( '.wp-post-image' ).removeClass( 'fadeInDown' ).addClass( 'animated fadeOutUp' );
 		jQuery( this ).children( '.secondary-image' ).removeClass( 'fadeOutUp' ).addClass( 'animated fadeInDown' );
+		// This makes the secondary image the same width as the primary. Use 'height: auto' in your css to retain proportions. This allows the hover feature to work well for responsive layouts.
+		jQuery( this ).children( '.secondary-image' ).css({'width': jQuery( this ).children( '.wp-post-image' ).width() + 'px'});
 	}, function() {
 		jQuery( this ).children( '.wp-post-image' ).removeClass( 'fadeOutUp' ).addClass( 'fadeInDown' );
 		jQuery( this ).children( '.secondary-image' ).removeClass( 'fadeInDown' ).addClass( 'fadeOutUp' );

--- a/image-flipper.php
+++ b/image-flipper.php
@@ -42,7 +42,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 			}
 
 
-	        /*-----------------------------------------------------------------------------------*/
+			/*-----------------------------------------------------------------------------------*/
 			/* Class Functions */
 			/*-----------------------------------------------------------------------------------*/
 
@@ -60,13 +60,17 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 
 				$post_type = get_post_type( get_the_ID() );
 
-				if ( $post_type == 'product' ) {
+				if ( ! is_admin() ) {
 
-					$attachment_ids = $product->get_gallery_attachment_ids();
+					if ( $post_type == 'product' ) {
 
-					if ( $attachment_ids ) {
-						$classes[] = 'pif-has-gallery';
+						$attachment_ids = $product->get_gallery_attachment_ids();
+
+						if ( $attachment_ids ) {
+							$classes[] = 'pif-has-gallery';
+						}
 					}
+
 				}
 
 				return $classes;


### PR DESCRIPTION
- Not all woocommerce templates put the product archive in `ul`/`li` tags. Removes these selectors to only use the classes.
- Added a line of js that gets the current width of the primary image and assigns it to the width of the secondary image. This means that the hover image will be the same size as the primary regardless of whether the primary image has been resized by css itself (which most responsive themes will do).
- The CSS animations seem to distort the image. I removed them and replaced with a simple opacity change with CSS transition.
