### PR TITLE
Fixed fatal error: get_gallery_attachment_ids() undefined

### DIFF
--- a/image-flipper.php
+++ b/image-flipper.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: WooCommerce Product Image Flipper
 Plugin URI: http://jameskoster.co.uk/tag/product-image-flipper/
-Version: 0.2.0
+Version: 0.2.1
 Description: Adds a secondary image on product archives that is revealed on hover. Perfect for displaying front/back shots of clothing and other products.
 Author: jameskoster
 Author URI: http://jameskoster.co.uk
@@ -55,7 +55,8 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 
 			// Add pif-has-gallery class to products that have a gallery
 			function product_has_gallery( $classes ) {
-				global $product;
+
+				$product = wc_get_product(  get_the_ID()  );
 
 				$post_type = get_post_type( get_the_ID() );
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jameskoster
 Tags: woocommerce, ecommerce, product, images, photos, product photos, front and back
 Requires at least: 3.8
 Tested up to: 4.0
-Stable tag: 0.2.0
+Stable tag: 0.2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -45,6 +45,9 @@ First of all check that the product you're checking has a gallery attached to it
 1. A flipped image.
 
 == Changelog ==
+
+= 0.2.1 =
+* Fix - Fixed fatal error: get_gallery_attachment_ids() undefined
 
 = 0.2.0 =
 * Fix - WooCommerce 2.2 compatibility


### PR DESCRIPTION
Across a few sites I was receiving a fatal error on the `get_gallery_attachment_ids` function. My fix uses wc_get_product(); instead of the global $product var to get the product class.

It's probably more intensive but it doesn't fail.

Cheers bro